### PR TITLE
Fix for AJAX-loading

### DIFF
--- a/FieldtypeStarRating.module
+++ b/FieldtypeStarRating.module
@@ -22,7 +22,7 @@ class FieldtypeStarRating extends Fieldtype {
   public static function getModuleInfo() {
     return array(
       'title' => 'Star Rating Integer',
-      'version' => 100,
+      'version' => 101,
       'summary' => 'Field that stores ratings as integer',
       'installs' => array('InputfieldStarRating')
     );

--- a/InputfieldStarRating.js
+++ b/InputfieldStarRating.js
@@ -1,11 +1,11 @@
 $(function() {
-  $('span.star').on('click', function(){
+  $(document).on('click', '.InputfieldStarRating span.star', function(){
     var rating = $(this).data('rating');
     $(this).closest('.InputfieldContent').find('input').val(rating);
     $(this).siblings().removeClass('active');
     $(this).addClass('active');
   });
-  $('span.reset').on('click', function(){
+  $(document).on('click', '.InputfieldStarRating span.reset', function(){
     var rating = 0;
     $(this).closest('.InputfieldContent').find('input').val(rating);
     $(this).siblings().removeClass('active');
@@ -19,6 +19,6 @@ $(function() {
       var rating = $(this).closest('.InputfieldContent').find('input').val();
       if (rating !== undefined) $(this).find('span.star[data-rating="' + rating + '"]').addClass('active');
     }
-  }, 'div.rating');
+  }, '.InputfieldStarRating div.rating');
 
 });

--- a/InputfieldStarRating.module
+++ b/InputfieldStarRating.module
@@ -23,7 +23,7 @@ class InputfieldStarRating extends Inputfield {
     return array(
       'title' => __('Star Rating Integer', __FILE__), // Module Title
       'summary' => __('Star Rating Integer', __FILE__), // Module Summary
-      'version' => 100,
+      'version' => 101,
     );
   }
 


### PR DESCRIPTION
Fix for when inputfield is AJAX-loaded, e.g. inside a repeater. Also made the jQuery selectors more specific (it's not unlikely that there could be a `span.reset` in Page Edit that's unrelated to this module) and bumped the version number.